### PR TITLE
Initialize OpenFastStruct with recursive hashes

### DIFF
--- a/lib/ofstruct.rb
+++ b/lib/ofstruct.rb
@@ -51,6 +51,10 @@ class OpenFastStruct
   end
 
   def assign(key, value)
-    @members[key.to_sym] = value
+    if value.is_a?(Hash)
+      @members[key.to_sym] = self.class.new(value)
+    else
+      @members[key.to_sym] = value
+    end
   end
 end

--- a/spec/lib/ofstruct_spec.rb
+++ b/spec/lib/ofstruct_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe OpenFastStruct do
     context "with hash" do
       let(:symbol_args) { { :name => "John" } }
       let(:string_args) { { "name" => "John" } }
+      let(:nested_args) { { person: { name: "John" } } }
+
+      context "with a nested hash" do
+        let(:args) { nested_args }
+
+        it "works with reader" do
+          expect(ofstruct.person.name).to eq("John")
+        end
+      end
 
       context "with symbol keys" do
         let(:args) { symbol_args }


### PR DESCRIPTION
## Description

This allows the initialization of an OpenFastStruct with recursive hashes.

Fix #24.